### PR TITLE
fix: resolve CLI flag conflict when user provides --agent in bracket syntax

### DIFF
--- a/src/runner/run-letta.ts
+++ b/src/runner/run-letta.ts
@@ -174,10 +174,13 @@ export function prepareRunConfig(
       (arg): arg is string => typeof arg === "string",
     );
 
-    // Extract --agent and --new flags from custom args to handle conflicts
+    // Extract --agent/-a and --new flags from custom args to handle conflicts
     let i = 0;
     while (i < allCustomArgs.length) {
-      if (allCustomArgs[i] === "--agent" && i + 1 < allCustomArgs.length) {
+      if (
+        (allCustomArgs[i] === "--agent" || allCustomArgs[i] === "-a") &&
+        i + 1 < allCustomArgs.length
+      ) {
         userRequestedAgentId = allCustomArgs[i + 1];
         i += 2; // Skip both --agent and its value
       } else if (allCustomArgs[i] === "--new") {

--- a/test/run-letta.test.ts
+++ b/test/run-letta.test.ts
@@ -71,6 +71,44 @@ describe("prepareRunConfig", () => {
       expect(config.lettaArgs).toContain("--new");
       expect(config.lettaArgs).not.toContain("--conversation");
     });
+
+    test("user -a (short alias) in lettaArgs overrides existing conversation", () => {
+      const config = prepareRunConfig(mockPromptPath, {
+        conversationId: "conv-123",
+        lettaArgs: "-a agent-456",
+      });
+      // Should use user's agent with --new, NOT the existing conversation
+      expect(config.lettaArgs).toContain("--agent");
+      expect(config.lettaArgs).toContain("agent-456");
+      expect(config.lettaArgs).toContain("--new");
+      // Should NOT contain the existing conversation
+      expect(config.lettaArgs).not.toContain("--conversation");
+      expect(config.lettaArgs).not.toContain("conv-123");
+      // Should NOT contain -a (it gets normalized to --agent)
+      expect(config.lettaArgs).not.toContain("-a");
+    });
+
+    test("user -a overrides configured agentId", () => {
+      const config = prepareRunConfig(mockPromptPath, {
+        agentId: "agent-configured",
+        conversationId: "conv-123",
+        lettaArgs: "-a agent-user-requested",
+      });
+      expect(config.lettaArgs).toContain("agent-user-requested");
+      expect(config.lettaArgs).not.toContain("agent-configured");
+      expect(config.lettaArgs).not.toContain("conv-123");
+    });
+
+    test("user -a with --new still works", () => {
+      const config = prepareRunConfig(mockPromptPath, {
+        conversationId: "conv-123",
+        lettaArgs: "-a agent-456 --new",
+      });
+      expect(config.lettaArgs).toContain("--agent");
+      expect(config.lettaArgs).toContain("agent-456");
+      expect(config.lettaArgs).toContain("--new");
+      expect(config.lettaArgs).not.toContain("--conversation");
+    });
   });
 
   describe("user --new flag handling", () => {


### PR DESCRIPTION
## Summary

Fixes a bug where the GitHub Action would fail with `Error: --conversation cannot be used with --agent` when:
1. An existing conversation exists for an issue/PR
2. User provides `[--agent <id>]` in bracket syntax to switch to a different agent

### Root Cause
The `prepareRunConfig` function was adding `--conversation` flag first, then appending user's custom args (including `--agent`) without checking for conflicts.

### Solution
Modified `prepareRunConfig` to:
- Parse custom args **first** to detect `--agent` and `--new` flags
- Prioritize user intent: if user explicitly requests a different agent, use it with `--new` (ignoring existing conversation)
- Log the decision for visibility in action logs

### Behavior Matrix

| Scenario | Result |
|----------|--------|
| `[--agent X]` + existing conversation | Use agent X with `--new` |
| `[--new]` + existing agent | Use existing agent with `--new` |
| `[--new]` without agent | Just `--new` (create new agent) |
| No bracket args + existing conversation | Resume conversation (unchanged) |

## Test Plan

- [x] Added 16 new unit tests for `prepareRunConfig` in `test/run-letta.test.ts`
- [x] All 442 existing tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Letta Code](https://letta.com)