### PR TITLE
Fix configured agent routing

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -117,6 +117,11 @@ export const agentMode: Mode = {
     // Just pass through any user-provided args (model overrides, etc.)
     const userLettaArgs = process.env.LETTA_ARGS || "";
 
+    if (context.inputs.agentId) {
+      core.setOutput("agent_id", context.inputs.agentId);
+      core.setOutput("create_new_conversation", "true");
+    }
+
     core.setOutput("letta_args", userLettaArgs.trim());
 
     return {

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -13,8 +13,21 @@ import { createPrompt, generateDefaultPrompt } from "../../create-prompt";
 import { isEntityContext } from "../../github/context";
 import type { PreparedContext } from "../../create-prompt/types";
 import type { FetchDataResult } from "../../github/data/fetcher";
-import { findExistingAgent } from "../../letta/find-existing-agent";
+import {
+  findExistingAgent,
+  type ExistingAgentInfo,
+} from "../../letta/find-existing-agent";
 import { parseTriggerFromContext } from "../../letta/trigger-parser";
+
+export function existingConversationMatchesConfiguredAgent(
+  configuredAgentId: string,
+  existingAgent: ExistingAgentInfo | null,
+): existingAgent is ExistingAgentInfo & { conversationId: string } {
+  return Boolean(
+    existingAgent?.conversationId &&
+      existingAgent.agentId === configuredAgentId,
+  );
+}
 
 /**
  * Tag mode implementation.
@@ -105,7 +118,21 @@ export const tagMode: Mode = {
         },
       );
 
-      if (existingAgent?.conversationId) {
+      if (
+        existingAgent?.conversationId &&
+        existingAgent.agentId !== configuredAgentId
+      ) {
+        console.log(
+          `Ignoring existing conversation ${existingAgent.conversationId} because it belongs to agent ${existingAgent.agentId}, not configured agent ${configuredAgentId}`,
+        );
+      }
+
+      if (
+        existingConversationMatchesConfiguredAgent(
+          configuredAgentId,
+          existingAgent,
+        )
+      ) {
         // Resume existing conversation
         console.log(
           `Resuming existing conversation: ${existingAgent.conversationId}`,

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -186,6 +186,45 @@ describe("Agent Mode", () => {
       process.env.GITHUB_REF_NAME = originalRefName;
   });
 
+  test("prepare method preserves configured agent for prompt workflows", async () => {
+    const contextWithAgent = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+      inputs: {
+        prompt: "Review this PR",
+        agentId: "agent-configured",
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "create_new_conversation",
+      "true",
+    );
+  });
+
   test("prepare method creates prompt file with correct content", async () => {
     const contextWithPrompts = createMockAutomationContext({
       eventName: "workflow_dispatch",

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { tagMode } from "../../src/modes/tag";
+import {
+  existingConversationMatchesConfiguredAgent,
+  tagMode,
+} from "../../src/modes/tag";
 import type { ParsedGitHubContext } from "../../src/github/context";
 import type { IssueCommentEvent } from "@octokit/webhooks-types";
 import { createMockContext } from "../mockContext";
@@ -88,5 +91,30 @@ describe("Tag Mode", () => {
 
   test("getDisallowedTools returns empty array", () => {
     expect(tagMode.getDisallowedTools()).toEqual([]);
+  });
+
+  test("configured agent only resumes conversations from the same agent", () => {
+    expect(
+      existingConversationMatchesConfiguredAgent("agent-configured", {
+        agentId: "agent-configured",
+        conversationId: "conv-existing",
+        commentId: 123,
+      }),
+    ).toBe(true);
+
+    expect(
+      existingConversationMatchesConfiguredAgent("agent-configured", {
+        agentId: "agent-other",
+        conversationId: "conv-existing",
+        commentId: 123,
+      }),
+    ).toBe(false);
+
+    expect(
+      existingConversationMatchesConfiguredAgent("agent-configured", {
+        agentId: "agent-configured",
+        commentId: 123,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Preserve `agent_id` in explicit-prompt/agent-mode workflows so automated jobs run on the configured Letta agent instead of the default/LRU agent.
- Avoid resuming a saved GitHub conversation when its metadata belongs to a different agent than the configured `agent_id`.
- Add regression coverage for agent-mode output and configured-agent conversation matching.

## Test plan
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run format:check`

👾 Generated with [Letta Code](https://letta.com)