### PR TITLE
feat: add tracking_comment input to skip tracking comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,10 @@ inputs:
     description: "Force tag mode with tracking comments for pull_request and issue events. Only applicable to pull_request (opened, synchronize, ready_for_review, reopened) and issue (opened, edited, labeled, assigned) events."
     required: false
     default: "false"
+  tracking_comment:
+    description: "Create a tracking comment on the PR/issue showing working status and results. Set to 'false' to skip the initial and final tracking comments (agent can still leave inline review comments)."
+    required: false
+    default: "true"
   path_to_letta_executable:
     description: "Optional path to a custom Letta Code executable. If provided, skips automatic installation and uses this executable instead."
     required: false
@@ -163,6 +167,7 @@ runs:
         BOT_ID: ${{ inputs.bot_id }}
         BOT_NAME: ${{ inputs.bot_name }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
+        TRACKING_COMMENT: ${{ inputs.tracking_comment }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         LETTA_ARGS: ${{ inputs.letta_args }}
         AGENT_ID: ${{ inputs.agent_id }}

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -709,12 +709,8 @@ export async function createPrompt(
     // Prepare the context for prompt generation
     let lettaCommentId: string = "";
     if (mode.name === "tag") {
-      if (!modeContext.commentId) {
-        throw new Error(
-          `${mode.name} mode requires a comment ID for prompt generation`,
-        );
-      }
-      lettaCommentId = modeContext.commentId.toString();
+      // commentId may be absent when tracking_comment is disabled
+      lettaCommentId = modeContext.commentId?.toString() ?? "";
     }
 
     const preparedContext = prepareContext(

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -95,6 +95,7 @@ type BaseContext = {
     allowedBots: string;
     allowedNonWriteUsers: string;
     trackProgress: boolean;
+    trackingComment: boolean;
     agentId?: string;
   };
 };
@@ -151,6 +152,7 @@ export function parseGitHubContext(): GitHubContext {
       allowedBots: process.env.ALLOWED_BOTS ?? "",
       allowedNonWriteUsers: process.env.ALLOWED_NON_WRITE_USERS ?? "",
       trackProgress: process.env.TRACK_PROGRESS === "true",
+      trackingComment: process.env.TRACKING_COMMENT !== "false",
       agentId: process.env.AGENT_ID || undefined,
     },
   };

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -71,7 +71,7 @@ export const agentMode: Mode = {
     return [];
   },
 
-  shouldCreateTrackingComment() {
+  shouldCreateTrackingComment(_context?: { inputs?: { trackingComment?: boolean } }) {
     return false;
   },
 

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -71,7 +71,9 @@ export const agentMode: Mode = {
     return [];
   },
 
-  shouldCreateTrackingComment(_context?: { inputs?: { trackingComment?: boolean } }) {
+  shouldCreateTrackingComment(_context?: {
+    inputs?: { trackingComment?: boolean };
+  }) {
     return false;
   },
 

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -25,7 +25,7 @@ export function existingConversationMatchesConfiguredAgent(
 ): existingAgent is ExistingAgentInfo & { conversationId: string } {
   return Boolean(
     existingAgent?.conversationId &&
-    existingAgent.agentId === configuredAgentId,
+      existingAgent.agentId === configuredAgentId,
   );
 }
 

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -25,7 +25,7 @@ export function existingConversationMatchesConfiguredAgent(
 ): existingAgent is ExistingAgentInfo & { conversationId: string } {
   return Boolean(
     existingAgent?.conversationId &&
-      existingAgent.agentId === configuredAgentId,
+    existingAgent.agentId === configuredAgentId,
   );
 }
 
@@ -70,7 +70,9 @@ export const tagMode: Mode = {
     return [];
   },
 
-  shouldCreateTrackingComment(context?: { inputs?: { trackingComment?: boolean } }) {
+  shouldCreateTrackingComment(context?: {
+    inputs?: { trackingComment?: boolean };
+  }) {
     return context?.inputs?.trackingComment ?? true;
   },
 

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -70,8 +70,8 @@ export const tagMode: Mode = {
     return [];
   },
 
-  shouldCreateTrackingComment() {
-    return true;
+  shouldCreateTrackingComment(context?: { inputs?: { trackingComment?: boolean } }) {
+    return context?.inputs?.trackingComment ?? true;
   },
 
   async prepare({
@@ -200,9 +200,14 @@ export const tagMode: Mode = {
       }
     }
 
-    // Create initial tracking comment
-    const commentData = await createInitialComment(octokit.rest, context);
-    const commentId = commentData.id;
+    // Create initial tracking comment (skip if tracking_comment is disabled)
+    let commentId: number | undefined;
+    if (context.inputs.trackingComment) {
+      const commentData = await createInitialComment(octokit.rest, context);
+      commentId = commentData.id;
+    } else {
+      console.log("Tracking comment disabled, skipping initial comment");
+    }
 
     const triggerTime = extractTriggerTimestamp(context);
 

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -55,7 +55,7 @@ export type Mode = {
   /**
    * Determines if this mode should create a tracking comment
    */
-  shouldCreateTrackingComment(): boolean;
+  shouldCreateTrackingComment(context?: { inputs?: { trackingComment?: boolean } }): boolean;
 
   /**
    * Generates the prompt for this mode.

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -55,7 +55,9 @@ export type Mode = {
   /**
    * Determines if this mode should create a tracking comment
    */
-  shouldCreateTrackingComment(context?: { inputs?: { trackingComment?: boolean } }): boolean;
+  shouldCreateTrackingComment(context?: {
+    inputs?: { trackingComment?: boolean };
+  }): boolean;
 
   /**
    * Generates the prompt for this mode.

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -25,6 +25,7 @@ const defaultInputs = {
   allowedBots: "",
   allowedNonWriteUsers: "",
   trackProgress: false,
+  trackingComment: true,
 };
 
 const defaultRepository = {

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -25,6 +25,7 @@ describe("detectMode with enhanced routing", () => {
       allowedBots: "",
       allowedNonWriteUsers: "",
       trackProgress: false,
+      trackingComment: true,
     },
   };
 

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -73,6 +73,7 @@ describe("checkWritePermissions", () => {
       allowedBots: "",
       allowedNonWriteUsers: "",
       trackProgress: false,
+      trackingComment: true,
     },
   });
 


### PR DESCRIPTION
## Summary
Add a `tracking_comment` input (default `true`) to the action. When set to `false`, the action skips creating the initial "Letta Code is working…" comment and the final update comment. The agent can still leave inline review comments via `gh api`. The check status still appears in PR checks.

This is useful for review workflows where the only signal should be inline comments on specific lines, not top-level noise on every push.

## Changes
- **action.yml**: add `tracking_comment` input, pass `TRACKING_COMMENT` env var
- **src/github/context.ts**: add `trackingComment` to `inputs` type, parse from env
- **src/modes/types.ts**: update `shouldCreateTrackingComment` signature
- **src/modes/tag/index.ts**: gate `createInitialComment()` on `context.inputs.trackingComment`
- **src/modes/agent/index.ts**: update `shouldCreateTrackingComment` signature

## Test plan
- [ ] Set `tracking_comment: false` in a workflow, verify no top-level comment is created
- [ ] Verify inline review comments still work
- [ ] Verify check status still appears in PR checks
- [ ] Verify default behavior (tracking_comment: true) is unchanged

🐾 Generated with [Letta Code](https://letta.com)