### PR TITLE
fix: agent mode respects tracking_comment and persists conversations

### DIFF
--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -21,11 +21,14 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
+export const LETTA_TRACKING_MARKER = "<!-- letta-tracking -->";
+
 export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
 ): string {
-  return `Letta Code is working… ${SPINNER_HTML}
+  return `${LETTA_TRACKING_MARKER}
+Letta Code is working… ${SPINNER_HTML}
 
 I'll analyze this and get back to you.
 

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -6,7 +6,11 @@
  */
 
 import { appendFileSync } from "fs";
-import { createJobRunLink, createCommentBody } from "./common";
+import {
+  createJobRunLink,
+  createCommentBody,
+  LETTA_TRACKING_MARKER,
+} from "./common";
 import {
   isPullRequestReviewCommentEvent,
   isPullRequestEvent,
@@ -38,13 +42,13 @@ export async function createInitialComment(
         issue_number: context.entityNumber,
       });
       const existingComment = comments.data.find((comment) => {
+        const markerMatch = comment.body?.includes(LETTA_TRACKING_MARKER);
         const idMatch = comment.user?.id === LETTA_APP_BOT_ID;
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("letta");
-        const bodyMatch = comment.body === initialBody;
 
-        return idMatch || botNameMatch || bodyMatch;
+        return markerMatch || idMatch || botNameMatch;
       });
       if (existingComment) {
         response = await octokit.rest.issues.updateComment({

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -5,6 +5,10 @@ import type { PreparedContext } from "../../create-prompt/types";
 import { configureGitAuth } from "../../github/operations/git-config";
 import type { GitHubContext } from "../../github/context";
 import { isEntityContext } from "../../github/context";
+import {
+  findExistingAgent,
+  type ExistingAgentInfo,
+} from "../../letta/find-existing-agent";
 
 /**
  * Extract GitHub context as environment variables for agent mode
@@ -43,8 +47,9 @@ function extractGitHubContext(context: GitHubContext): Record<string, string> {
  * Agent mode implementation.
  *
  * This mode runs whenever an explicit prompt is provided in the workflow configuration.
- * It bypasses the standard @letta mention checking and comment tracking used by tag mode,
- * providing direct access to Letta Code for automation workflows.
+ * When tracking_comment is enabled, it supports conversation persistence across runs
+ * on the same PR/issue (same as tag mode). When disabled, it behaves as a stateless
+ * automation runner.
  */
 export const agentMode: Mode = {
   name: "agent",
@@ -56,7 +61,6 @@ export const agentMode: Mode = {
   },
 
   prepareContext(context) {
-    // Agent mode doesn't use comment tracking or branch management
     return {
       mode: "agent",
       githubContext: context,
@@ -71,13 +75,13 @@ export const agentMode: Mode = {
     return [];
   },
 
-  shouldCreateTrackingComment(_context?: {
+  shouldCreateTrackingComment(context?: {
     inputs?: { trackingComment?: boolean };
   }) {
-    return false;
+    return context?.inputs?.trackingComment ?? false;
   },
 
-  async prepare({ context, githubToken }: ModeOptions): Promise<ModeResult> {
+  async prepare({ context, octokit, githubToken }: ModeOptions): Promise<ModeResult> {
     // Configure git authentication for agent mode (same as tag mode)
     if (!context.inputs.useCommitSigning) {
       // Use bot_id and bot_name from inputs directly
@@ -119,7 +123,43 @@ export const agentMode: Mode = {
     // Just pass through any user-provided args (model overrides, etc.)
     const userLettaArgs = process.env.LETTA_ARGS || "";
 
-    if (context.inputs.agentId) {
+    // Conversation persistence: search for existing conversation on this PR
+    if (context.inputs.agentId && isEntityContext(context)) {
+      core.setOutput("agent_id", context.inputs.agentId);
+
+      const existingAgent = await findExistingAgent(
+        octokit.rest,
+        context.repository.owner,
+        context.repository.repo,
+        context.entityNumber,
+        {
+          isPR: context.isPR,
+          prBody: context.isPR
+            ? (context.payload?.pull_request?.body ?? null)
+            : null,
+        },
+      );
+
+      if (
+        existingAgent?.conversationId &&
+        existingAgent.agentId === context.inputs.agentId
+      ) {
+        // Resume existing conversation
+        console.log(
+          `Resuming existing conversation: ${existingAgent.conversationId}`,
+        );
+        core.setOutput("conversation_id", existingAgent.conversationId);
+        core.setOutput("is_followup", "true");
+        core.setOutput("create_new_conversation", "false");
+      } else {
+        // No existing conversation for this agent - create new one
+        console.log(
+          "No existing conversation found, will create new conversation on configured agent",
+        );
+        core.setOutput("is_followup", "false");
+        core.setOutput("create_new_conversation", "true");
+      }
+    } else if (context.inputs.agentId) {
       core.setOutput("agent_id", context.inputs.agentId);
       core.setOutput("create_new_conversation", "true");
     }

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -5,10 +5,7 @@ import type { PreparedContext } from "../../create-prompt/types";
 import { configureGitAuth } from "../../github/operations/git-config";
 import type { GitHubContext } from "../../github/context";
 import { isEntityContext } from "../../github/context";
-import {
-  findExistingAgent,
-  type ExistingAgentInfo,
-} from "../../letta/find-existing-agent";
+import { findExistingAgent } from "../../letta/find-existing-agent";
 
 /**
  * Extract GitHub context as environment variables for agent mode
@@ -81,7 +78,11 @@ export const agentMode: Mode = {
     return context?.inputs?.trackingComment ?? false;
   },
 
-  async prepare({ context, octokit, githubToken }: ModeOptions): Promise<ModeResult> {
+  async prepare({
+    context,
+    octokit,
+    githubToken,
+  }: ModeOptions): Promise<ModeResult> {
     // Configure git authentication for agent mode (same as tag mode)
     if (!context.inputs.useCommitSigning) {
       // Use bot_id and bot_name from inputs directly
@@ -135,7 +136,8 @@ export const agentMode: Mode = {
         {
           isPR: context.isPR,
           prBody: context.isPR
-            ? (context.payload?.pull_request?.body ?? null)
+            ? ((context.payload as { pull_request?: { body?: string } })
+                .pull_request?.body ?? null)
             : null,
         },
       );

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -6,6 +6,7 @@ import { configureGitAuth } from "../../github/operations/git-config";
 import type { GitHubContext } from "../../github/context";
 import { isEntityContext } from "../../github/context";
 import { findExistingAgent } from "../../letta/find-existing-agent";
+import { createInitialComment } from "../../github/operations/comments/create-initial";
 
 /**
  * Extract GitHub context as environment variables for agent mode
@@ -124,6 +125,17 @@ export const agentMode: Mode = {
     // Just pass through any user-provided args (model overrides, etc.)
     const userLettaArgs = process.env.LETTA_ARGS || "";
 
+    // Create tracking comment if enabled (for conversation persistence)
+    let commentId: number | undefined;
+    if (context.inputs.trackingComment && isEntityContext(context)) {
+      const commentData = await createInitialComment(octokit.rest, context);
+      commentId = commentData.id;
+    } else if (context.inputs.trackingComment) {
+      console.log(
+        "Tracking comment enabled but not on entity context, skipping initial comment",
+      );
+    }
+
     // Conversation persistence: search for existing conversation on this PR
     if (context.inputs.agentId && isEntityContext(context)) {
       core.setOutput("agent_id", context.inputs.agentId);
@@ -169,7 +181,7 @@ export const agentMode: Mode = {
     core.setOutput("letta_args", userLettaArgs.trim());
 
     return {
-      commentId: undefined,
+      commentId,
       branchInfo: {
         baseBranch: baseBranch,
         currentBranch: baseBranch, // Use base branch as current when creating new branch

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -60,8 +60,16 @@ describe("Agent Mode", () => {
       "Direct automation mode for explicit prompts",
     );
     expect(agentMode.shouldCreateTrackingComment()).toBe(false);
-    expect(agentMode.shouldCreateTrackingComment({ inputs: { trackingComment: true } })).toBe(true);
-    expect(agentMode.shouldCreateTrackingComment({ inputs: { trackingComment: false } })).toBe(false);
+    expect(
+      agentMode.shouldCreateTrackingComment({
+        inputs: { trackingComment: true },
+      }),
+    ).toBe(true);
+    expect(
+      agentMode.shouldCreateTrackingComment({
+        inputs: { trackingComment: false },
+      }),
+    ).toBe(false);
     expect(agentMode.getAllowedTools()).toEqual([]);
     expect(agentMode.getDisallowedTools()).toEqual([]);
   });
@@ -278,9 +286,15 @@ describe("Agent Mode", () => {
     });
 
     expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
-    expect(setOutputSpy).toHaveBeenCalledWith("conversation_id", "conv-existing-123");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "conversation_id",
+      "conv-existing-123",
+    );
     expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "true");
-    expect(setOutputSpy).toHaveBeenCalledWith("create_new_conversation", "false");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "create_new_conversation",
+      "false",
+    );
   });
 
   test("prepare method creates new conversation when no existing conversation found on entity context", async () => {
@@ -323,7 +337,10 @@ describe("Agent Mode", () => {
 
     expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
     expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "false");
-    expect(setOutputSpy).toHaveBeenCalledWith("create_new_conversation", "true");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "create_new_conversation",
+      "true",
+    );
   });
 
   test("prepare method creates prompt file with correct content", async () => {

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -12,12 +12,14 @@ import type { GitHubContext } from "../../src/github/context";
 import { createMockContext, createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
+import * as findExistingAgent from "../../src/letta/find-existing-agent";
 
 describe("Agent Mode", () => {
   let mockContext: GitHubContext;
   let exportVariableSpy: any;
   let setOutputSpy: any;
   let configureGitAuthSpy: any;
+  let findExistingAgentSpy: any;
 
   beforeEach(() => {
     mockContext = createMockAutomationContext({
@@ -34,15 +36,22 @@ describe("Agent Mode", () => {
     ).mockImplementation(async () => {
       // Do nothing - prevent actual git config modifications
     });
+    // Mock findExistingAgent to prevent API calls
+    findExistingAgentSpy = spyOn(
+      findExistingAgent,
+      "findExistingAgent",
+    ).mockImplementation(async () => null);
   });
 
   afterEach(() => {
     exportVariableSpy?.mockClear();
     setOutputSpy?.mockClear();
     configureGitAuthSpy?.mockClear();
+    findExistingAgentSpy?.mockClear();
     exportVariableSpy?.mockRestore();
     setOutputSpy?.mockRestore();
     configureGitAuthSpy?.mockRestore();
+    findExistingAgentSpy?.mockRestore();
   });
 
   test("agent mode has correct properties", () => {
@@ -51,6 +60,8 @@ describe("Agent Mode", () => {
       "Direct automation mode for explicit prompts",
     );
     expect(agentMode.shouldCreateTrackingComment()).toBe(false);
+    expect(agentMode.shouldCreateTrackingComment({ inputs: { trackingComment: true } })).toBe(true);
+    expect(agentMode.shouldCreateTrackingComment({ inputs: { trackingComment: false } })).toBe(false);
     expect(agentMode.getAllowedTools()).toEqual([]);
     expect(agentMode.getDisallowedTools()).toEqual([]);
   });
@@ -60,7 +71,6 @@ describe("Agent Mode", () => {
 
     expect(context.mode).toBe("agent");
     expect(context.githubContext).toBe(mockContext);
-    // Agent mode doesn't use comment tracking or branch management
     expect(Object.keys(context)).toEqual(["mode", "githubContext"]);
   });
 
@@ -223,6 +233,97 @@ describe("Agent Mode", () => {
       "create_new_conversation",
       "true",
     );
+  });
+
+  test("prepare method resumes existing conversation on entity context (PR)", async () => {
+    const contextWithAgent = createMockContext({
+      eventName: "pull_request",
+      inputs: {
+        prompt: "Review this PR",
+        agentId: "agent-configured",
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+        },
+        issues: {
+          listComments: mock(() => Promise.resolve({ data: [] })),
+        },
+      },
+    } as any;
+
+    // Mock findExistingAgent to return an existing conversation
+    findExistingAgentSpy.mockImplementation(async () => ({
+      agentId: "agent-configured",
+      conversationId: "conv-existing-123",
+      commentId: 999,
+    }));
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
+    expect(setOutputSpy).toHaveBeenCalledWith("conversation_id", "conv-existing-123");
+    expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "true");
+    expect(setOutputSpy).toHaveBeenCalledWith("create_new_conversation", "false");
+  });
+
+  test("prepare method creates new conversation when no existing conversation found on entity context", async () => {
+    const contextWithAgent = createMockContext({
+      eventName: "pull_request",
+      inputs: {
+        prompt: "Review this PR",
+        agentId: "agent-configured",
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345 },
+            }),
+          ),
+        },
+        issues: {
+          listComments: mock(() => Promise.resolve({ data: [] })),
+        },
+      },
+    } as any;
+
+    // Mock findExistingAgent to return null (no existing conversation)
+    findExistingAgentSpy.mockImplementation(async () => null);
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
+    expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "false");
+    expect(setOutputSpy).toHaveBeenCalledWith("create_new_conversation", "true");
   });
 
   test("prepare method creates prompt file with correct content", async () => {

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -13,6 +13,7 @@ import { createMockContext, createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
 import * as findExistingAgent from "../../src/letta/find-existing-agent";
+import * as createInitialComment from "../../src/github/operations/comments/create-initial";
 
 describe("Agent Mode", () => {
   let mockContext: GitHubContext;
@@ -20,6 +21,7 @@ describe("Agent Mode", () => {
   let setOutputSpy: any;
   let configureGitAuthSpy: any;
   let findExistingAgentSpy: any;
+  let createInitialCommentSpy: any;
 
   beforeEach(() => {
     mockContext = createMockAutomationContext({
@@ -41,6 +43,11 @@ describe("Agent Mode", () => {
       findExistingAgent,
       "findExistingAgent",
     ).mockImplementation(async () => null);
+    // Mock createInitialComment to prevent API calls
+    createInitialCommentSpy = spyOn(
+      createInitialComment,
+      "createInitialComment",
+    ).mockImplementation(async () => ({ id: 12345 }) as any);
   });
 
   afterEach(() => {
@@ -48,10 +55,12 @@ describe("Agent Mode", () => {
     setOutputSpy?.mockClear();
     configureGitAuthSpy?.mockClear();
     findExistingAgentSpy?.mockClear();
+    createInitialCommentSpy?.mockClear();
     exportVariableSpy?.mockRestore();
     setOutputSpy?.mockRestore();
     configureGitAuthSpy?.mockRestore();
     findExistingAgentSpy?.mockRestore();
+    createInitialCommentSpy?.mockRestore();
   });
 
   test("agent mode has correct properties", () => {
@@ -252,25 +261,7 @@ describe("Agent Mode", () => {
       },
     });
 
-    const mockOctokit = {
-      rest: {
-        users: {
-          getAuthenticated: mock(() =>
-            Promise.resolve({
-              data: { login: "test-user", id: 12345 },
-            }),
-          ),
-          getByUsername: mock(() =>
-            Promise.resolve({
-              data: { login: "test-user", id: 12345 },
-            }),
-          ),
-        },
-        issues: {
-          listComments: mock(() => Promise.resolve({ data: [] })),
-        },
-      },
-    } as any;
+    const mockOctokit = { rest: {} } as any;
 
     // Mock findExistingAgent to return an existing conversation
     findExistingAgentSpy.mockImplementation(async () => ({
@@ -279,7 +270,7 @@ describe("Agent Mode", () => {
       commentId: 999,
     }));
 
-    await agentMode.prepare({
+    const result = await agentMode.prepare({
       context: contextWithAgent,
       octokit: mockOctokit,
       githubToken: "test-token",
@@ -295,6 +286,8 @@ describe("Agent Mode", () => {
       "create_new_conversation",
       "false",
     );
+    expect(createInitialCommentSpy).toHaveBeenCalled();
+    expect(result.commentId).toBe(12345);
   });
 
   test("prepare method creates new conversation when no existing conversation found on entity context", async () => {
@@ -306,30 +299,12 @@ describe("Agent Mode", () => {
       },
     });
 
-    const mockOctokit = {
-      rest: {
-        users: {
-          getAuthenticated: mock(() =>
-            Promise.resolve({
-              data: { login: "test-user", id: 12345 },
-            }),
-          ),
-          getByUsername: mock(() =>
-            Promise.resolve({
-              data: { login: "test-user", id: 12345 },
-            }),
-          ),
-        },
-        issues: {
-          listComments: mock(() => Promise.resolve({ data: [] })),
-        },
-      },
-    } as any;
+    const mockOctokit = { rest: {} } as any;
 
     // Mock findExistingAgent to return null (no existing conversation)
     findExistingAgentSpy.mockImplementation(async () => null);
 
-    await agentMode.prepare({
+    const result = await agentMode.prepare({
       context: contextWithAgent,
       octokit: mockOctokit,
       githubToken: "test-token",
@@ -341,6 +316,8 @@ describe("Agent Mode", () => {
       "create_new_conversation",
       "true",
     );
+    expect(createInitialCommentSpy).toHaveBeenCalled();
+    expect(result.commentId).toBe(12345);
   });
 
   test("prepare method creates prompt file with correct content", async () => {


### PR DESCRIPTION
## Summary
Agent mode was hardcoding `shouldCreateTrackingComment` to `false` and always creating new conversations, ignoring the `tracking_comment` and `use_sticky_comment` inputs. This meant review workflows that set `tracking_comment: true` never got a tracking comment, so `conversation_id` was never stored, and every run started a fresh conversation.

### Changes
- `shouldCreateTrackingComment` now respects the `trackingComment` input (defaults to `false` for backward compatibility)
- `prepare()` now calls `findExistingAgent` on entity contexts (PRs/issues) to search for existing conversations, same as tag mode
- When an existing conversation is found for the configured agent, it resumes it instead of creating a new one
- Added tests for conversation resumption and new conversation creation

### Root cause
The review workflow in letta-code sets `tracking_comment: "true"` and `use_sticky_comment: "true"`, but agent mode ignored both inputs. The sticky comment was never created, so there was nowhere to store the `<!-- letta-metadata conversation_id: conv-xxx -->` block. On subsequent pushes, `findExistingAgent()` found nothing and started a fresh conversation every time.

## Test plan
- [x] All 450 existing tests pass
- [x] New tests for conversation resumption on entity context
- [x] New tests for new conversation creation when no existing conversation found
- [ ] After merging, verify the review workflow creates a sticky comment and reuses conversations on subsequent pushes