### PR TITLE
feat: conversation persistence via Letta API summary lookup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -171,6 +171,7 @@ runs:
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         LETTA_ARGS: ${{ inputs.letta_args }}
         AGENT_ID: ${{ inputs.agent_id }}
+        LETTA_API_KEY: ${{ inputs.letta_api_key }}
         ALL_INPUTS: ${{ toJson(inputs) }}
 
     - name: Install Base Action Dependencies

--- a/src/letta/client.ts
+++ b/src/letta/client.ts
@@ -107,6 +107,66 @@ export async function getLatestConversation(
 }
 
 /**
+ * Find an existing conversation for an agent by its summary.
+ * Used to resume conversations across review runs on the same PR/issue.
+ *
+ * @param agentId - The agent ID to search conversations for
+ * @param summary - The summary to match (e.g., "owner/repo/pr-123")
+ * @param apiKey - Optional API key (reads from LETTA_API_KEY or INPUT_LETTA_API_KEY if not provided)
+ * @returns The most recent matching conversation ID, or null
+ */
+export async function findConversationBySummary(
+  agentId: string,
+  summary: string,
+  apiKey?: string,
+): Promise<string | null> {
+  const key = apiKey || process.env.LETTA_API_KEY;
+
+  if (!key) {
+    console.warn("LETTA_API_KEY not set, cannot search conversations");
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    agent_id: agentId,
+    summary,
+    limit: "1",
+    order: "desc",
+  });
+  const url = `${LETTA_API_BASE_URL}/v1/conversations/?${params}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${key}`,
+      },
+    });
+
+    if (!response.ok) {
+      console.error(`Failed to search conversations: ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as Array<{
+      id: string;
+      summary: string;
+    }>;
+    const match = data?.[0];
+    if (match) {
+      console.log(`Found existing conversation for ${summary}: ${match.id}`);
+      return match.id;
+    }
+
+    console.log(`No existing conversation found for ${summary}`);
+    return null;
+  } catch (error) {
+    console.error("Error searching conversations:", error);
+    return null;
+  }
+}
+
+/**
  * Get agent details from the Letta API.
  */
 export async function getAgentInfo(

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -5,6 +5,10 @@ import type { PreparedContext } from "../../create-prompt/types";
 import { configureGitAuth } from "../../github/operations/git-config";
 import type { GitHubContext } from "../../github/context";
 import { isEntityContext } from "../../github/context";
+import {
+  findConversationBySummary,
+  buildConversationSummary,
+} from "../../letta/client";
 
 /**
  * Extract GitHub context as environment variables for agent mode
@@ -43,8 +47,9 @@ function extractGitHubContext(context: GitHubContext): Record<string, string> {
  * Agent mode implementation.
  *
  * This mode runs whenever an explicit prompt is provided in the workflow configuration.
- * It bypasses the standard @letta mention checking and comment tracking used by tag mode,
- * providing direct access to Letta Code for automation workflows.
+ * On entity contexts (PRs/issues), it searches for existing conversations via the
+ * Letta API (matching on conversation summary) so that subsequent runs on the same
+ * PR/issue resume the existing conversation instead of starting fresh.
  */
 export const agentMode: Mode = {
   name: "agent",
@@ -56,7 +61,6 @@ export const agentMode: Mode = {
   },
 
   prepareContext(context) {
-    // Agent mode doesn't use comment tracking or branch management
     return {
       mode: "agent",
       githubContext: context,
@@ -119,7 +123,35 @@ export const agentMode: Mode = {
     // Just pass through any user-provided args (model overrides, etc.)
     const userLettaArgs = process.env.LETTA_ARGS || "";
 
-    if (context.inputs.agentId) {
+    // Conversation persistence: search for existing conversation via Letta API
+    if (context.inputs.agentId && isEntityContext(context)) {
+      core.setOutput("agent_id", context.inputs.agentId);
+
+      const summary = buildConversationSummary(
+        context.isPR ? "PR" : "Issue",
+        context.entityNumber,
+        context.repository.full_name,
+      );
+
+      const existingConversationId = await findConversationBySummary(
+        context.inputs.agentId,
+        summary,
+      );
+
+      if (existingConversationId) {
+        // Resume existing conversation
+        core.setOutput("conversation_id", existingConversationId);
+        core.setOutput("is_followup", "true");
+        core.setOutput("create_new_conversation", "false");
+      } else {
+        // No existing conversation - create new one
+        console.log(
+          "No existing conversation found, will create new conversation",
+        );
+        core.setOutput("is_followup", "false");
+        core.setOutput("create_new_conversation", "true");
+      }
+    } else if (context.inputs.agentId) {
       core.setOutput("agent_id", context.inputs.agentId);
       core.setOutput("create_new_conversation", "true");
     }

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -12,12 +12,14 @@ import type { GitHubContext } from "../../src/github/context";
 import { createMockContext, createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
+import * as lettaClient from "../../src/letta/client";
 
 describe("Agent Mode", () => {
   let mockContext: GitHubContext;
   let exportVariableSpy: any;
   let setOutputSpy: any;
   let configureGitAuthSpy: any;
+  let findConversationBySummarySpy: any;
 
   beforeEach(() => {
     mockContext = createMockAutomationContext({
@@ -34,15 +36,22 @@ describe("Agent Mode", () => {
     ).mockImplementation(async () => {
       // Do nothing - prevent actual git config modifications
     });
+    // Mock findConversationBySummary to prevent API calls
+    findConversationBySummarySpy = spyOn(
+      lettaClient,
+      "findConversationBySummary",
+    ).mockImplementation(async () => null);
   });
 
   afterEach(() => {
     exportVariableSpy?.mockClear();
     setOutputSpy?.mockClear();
     configureGitAuthSpy?.mockClear();
+    findConversationBySummarySpy?.mockClear();
     exportVariableSpy?.mockRestore();
     setOutputSpy?.mockRestore();
     configureGitAuthSpy?.mockRestore();
+    findConversationBySummarySpy?.mockRestore();
   });
 
   test("agent mode has correct properties", () => {
@@ -262,5 +271,67 @@ describe("Agent Mode", () => {
     expect(callArgs[0]).toBe("letta_args");
     // Should be empty or just whitespace when no MCP servers are included
     expect(callArgs[1]).not.toContain("--mcp-config");
+  });
+
+  test("prepare method resumes existing conversation on entity context (PR)", async () => {
+    const contextWithAgent = createMockContext({
+      eventName: "pull_request",
+      inputs: {
+        prompt: "Review this PR",
+        agentId: "agent-configured",
+      },
+    });
+
+    const mockOctokit = { rest: {} } as any;
+
+    // Mock findConversationBySummary to return an existing conversation
+    findConversationBySummarySpy.mockImplementation(
+      async () => "conv-existing-123",
+    );
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "conversation_id",
+      "conv-existing-123",
+    );
+    expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "true");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "create_new_conversation",
+      "false",
+    );
+  });
+
+  test("prepare method creates new conversation when no existing conversation found on entity context", async () => {
+    const contextWithAgent = createMockContext({
+      eventName: "pull_request",
+      inputs: {
+        prompt: "Review this PR",
+        agentId: "agent-configured",
+      },
+    });
+
+    const mockOctokit = { rest: {} } as any;
+
+    // Mock findConversationBySummary to return null (no existing conversation)
+    findConversationBySummarySpy.mockImplementation(async () => null);
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(setOutputSpy).toHaveBeenCalledWith("agent_id", "agent-configured");
+    expect(setOutputSpy).toHaveBeenCalledWith("is_followup", "false");
+    expect(setOutputSpy).toHaveBeenCalledWith(
+      "create_new_conversation",
+      "true",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add `findConversationBySummary()` to `letta/client.ts` — searches the Letta API for existing conversations by agent ID + summary (e.g., `owner/repo/pr-123`)
- Update agent mode `prepare()` to search for existing conversations on entity contexts (PRs/issues) before creating new ones
- If a matching conversation is found, sets `create_new_conversation: false` and `conversation_id` for resumption
- If no match, creates a new conversation as before

This replaces the previous approach of scraping GitHub comments for `<!-- letta-metadata -->` blocks. The Letta API already sets conversation summaries to `owner/repo/pr-N` format, so we just query for it.

## Files changed
- `src/letta/client.ts` — new `findConversationBySummary()` function
- `src/modes/agent/index.ts` — conversation lookup in `prepare()`
- `test/modes/agent.test.ts` — 2 new tests for resume + new conversation

👾 Generated with [Letta Code](https://letta.com)