### PR TITLE
fix: handle fork pull request checkout

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -646,7 +646,7 @@ Important Notes:
 - This includes ALL responses: code reviews, answers to questions, progress updates, and final results.${eventData.isPR ? `\n- PR CRITICAL: After reading files and forming your response, you MUST post it by updating your tracking comment via gh api. Do NOT just respond with a normal response, the user will not see it.` : ""}
 - You communicate exclusively by editing your single comment - not through any other means.
 - Use this spinner HTML when work is in progress: <img src="https://github.com/user-attachments/assets/05be199b-c834-407f-8371-6f4b91435b71" width="14px" height="14px" style="vertical-align: middle; margin-left: 4px;" />
-${eventData.isPR && !eventData.lettaBranch ? `- Always push to the existing branch when triggered on a PR.` : `- IMPORTANT: You are already on the correct branch (${eventData.lettaBranch || "the created branch"}). Never create new branches when triggered on issues or closed/merged PRs.`}
+${eventData.isPR && !eventData.lettaBranch ? `- Always push to the existing branch when triggered on a PR.` : `- IMPORTANT: You are already on the correct branch (${eventData.lettaBranch || "the created branch"}). Never create new branches when a Letta branch has already been prepared for you.`}
 - Use git commands via the Bash tool for version control:
   - Stage files: Bash(git add <files>)
   - Commit changes: Bash(git commit -m "<message>")
@@ -670,7 +670,8 @@ What You CAN Do:
 - Create pull requests for changes to human-authored code
 - Smart branch handling:
   - When triggered on an issue: First check the conversation history for existing PRs/branches from prior Letta work. If found, iterate on that existing branch instead of creating a new one.
-  - When triggered on an open PR: Always push directly to the existing PR branch
+  - When triggered on an open same-repository PR: Push directly to the existing PR branch
+  - When triggered on an open fork PR: Work on the provided Letta branch and create a maintainer-side PR back to the base branch
   - When triggered on a closed PR: Create a new branch
   - CRITICAL: When a user requests changes to work you've already done, ALWAYS iterate on the existing branch. Never create a new branch for follow-up changes - this breaks PR links and creates unnecessary work.
 

--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -12,6 +12,7 @@ export const PR_QUERY = `
         baseRefName
         headRefName
         headRefOid
+        isCrossRepository
         createdAt
         updatedAt
         lastEditedAt

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -234,37 +234,7 @@ export async function fetchGitHubData({
     throw new Error(`Failed to fetch ${isPR ? "PR" : "issue"} data`);
   }
 
-  // Compute SHAs for changed files
-  let changedFilesWithSHA: GitHubFileWithSHA[] = [];
-  if (isPR && changedFiles.length > 0) {
-    changedFilesWithSHA = changedFiles.map((file) => {
-      // Don't compute SHA for deleted files
-      if (file.changeType === "DELETED") {
-        return {
-          ...file,
-          sha: "deleted",
-        };
-      }
-
-      try {
-        // Use git hash-object to compute the SHA for the current file content
-        const sha = execFileSync("git", ["hash-object", file.path], {
-          encoding: "utf-8",
-        }).trim();
-        return {
-          ...file,
-          sha,
-        };
-      } catch (error) {
-        console.warn(`Failed to compute SHA for ${file.path}:`, error);
-        // Return original file without SHA if computation fails
-        return {
-          ...file,
-          sha: "unknown",
-        };
-      }
-    });
-  }
+  const changedFilesWithSHA: GitHubFileWithSHA[] = [];
 
   // Prepare all comments for image processing
   const issueComments: CommentWithImages[] = comments
@@ -363,6 +333,40 @@ export async function fetchGitHubData({
     imageUrlMap,
     triggerDisplayName,
   };
+}
+
+export function computeChangedFileSHAs(
+  isPR: boolean,
+  changedFiles: GitHubFile[],
+): GitHubFileWithSHA[] {
+  if (!isPR || changedFiles.length === 0) {
+    return [];
+  }
+
+  return changedFiles.map((file) => {
+    if (file.changeType === "DELETED") {
+      return {
+        ...file,
+        sha: "deleted",
+      };
+    }
+
+    try {
+      const sha = execFileSync("git", ["hash-object", "--", file.path], {
+        encoding: "utf-8",
+      }).trim();
+      return {
+        ...file,
+        sha,
+      };
+    } catch (error) {
+      console.warn(`Failed to compute SHA for ${file.path}:`, error);
+      return {
+        ...file,
+        sha: "unknown",
+      };
+    }
+  });
 }
 
 export type UserQueryResponse = {

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -338,6 +338,7 @@ export async function fetchGitHubData({
 export function computeChangedFileSHAs(
   isPR: boolean,
   changedFiles: GitHubFile[],
+  cwd?: string,
 ): GitHubFileWithSHA[] {
   if (!isPR || changedFiles.length === 0) {
     return [];
@@ -354,6 +355,7 @@ export function computeChangedFileSHAs(
     try {
       const sha = execFileSync("git", ["hash-object", "--", file.path], {
         encoding: "utf-8",
+        cwd,
       }).trim();
       return {
         ...file,

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -23,7 +23,20 @@ export type PullRequestBranchPlan = {
   fetchRef: string;
   checkoutBranch: string;
   lettaBranch?: string;
+  legacyLettaBranch?: string;
 };
+
+export type SetupBranchOptions = {
+  cwd?: string;
+  setOutput?: typeof core.setOutput;
+};
+
+function withCwd(
+  command: ReturnType<typeof $>,
+  cwd?: string,
+): ReturnType<typeof $> {
+  return cwd ? command.cwd(cwd) : command;
+}
 
 export function getPullRequestBranchPlan(
   entityNumber: number,
@@ -34,31 +47,133 @@ export function getPullRequestBranchPlan(
   const checkoutBranch = isCrossRepository
     ? `letta-pr-${entityNumber}`
     : headRefName;
+  const reviewBranchSuffix = `pr-${entityNumber}-review`;
+  const normalizedReviewBranchPrefix = branchPrefix.toLowerCase();
+  const legacyLettaBranch =
+    `${normalizedReviewBranchPrefix}${reviewBranchSuffix}`.substring(0, 50);
+  const maxReviewBranchPrefixLength = Math.max(
+    0,
+    50 - reviewBranchSuffix.length,
+  );
+  let reviewBranchPrefix = normalizedReviewBranchPrefix.substring(
+    0,
+    maxReviewBranchPrefixLength,
+  );
+
+  if (normalizedReviewBranchPrefix.length > maxReviewBranchPrefixLength) {
+    reviewBranchPrefix = reviewBranchPrefix.replace(/[^/-]*$/, "");
+  }
+
+  const lettaBranch = `${reviewBranchPrefix}${reviewBranchSuffix}`;
+
   return {
     fetchRef: `refs/pull/${entityNumber}/head`,
     checkoutBranch,
     ...(isCrossRepository && {
-      lettaBranch: `${branchPrefix}pr-${entityNumber}-review`
-        .toLowerCase()
-        .substring(0, 50),
+      lettaBranch,
+      ...(legacyLettaBranch !== lettaBranch && {
+        legacyLettaBranch,
+      }),
     }),
   };
 }
 
-async function remoteBranchExists(branchName: string): Promise<boolean> {
+async function remoteBranchExists(
+  branchName: string,
+  cwd?: string,
+): Promise<boolean> {
+  const expectedRef = `refs/heads/${branchName}`;
   try {
-    await $`git ls-remote --exit-code --heads origin ${branchName}`.quiet();
+    const output = await withCwd(
+      $`git ls-remote --heads origin ${expectedRef}`,
+      cwd,
+    )
+      .quiet()
+      .text();
+    return output
+      .split("\n")
+      .some((line) => line.split(/\s+/)[1] === expectedRef);
+  } catch {
+    return false;
+  }
+}
+
+async function isValidBranchName(
+  branchName: string,
+  cwd?: string,
+): Promise<boolean> {
+  try {
+    await withCwd($`git check-ref-format --branch ${branchName}`, cwd).quiet();
     return true;
   } catch {
     return false;
   }
 }
 
+async function assertValidBranchName(
+  branchName: string,
+  cwd?: string,
+): Promise<void> {
+  if (!(await isValidBranchName(branchName, cwd))) {
+    throw new Error(
+      `Invalid generated branch name "${branchName}". Check branch_prefix; generated review branches must be valid git branch names.`,
+    );
+  }
+}
+
+async function branchContainsCommit(
+  branchName: string,
+  commitish: string,
+  cwd?: string,
+): Promise<boolean> {
+  try {
+    await withCwd(
+      $`git merge-base --is-ancestor ${commitish} ${branchName}`,
+      cwd,
+    ).quiet();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function deepenRemoteBranchHistory(
+  branchName: string,
+  cwd?: string,
+): Promise<void> {
+  try {
+    await withCwd(
+      $`git fetch origin --unshallow +refs/heads/${branchName}:${branchName}`,
+      cwd,
+    ).quiet();
+    return;
+  } catch {
+    // Fall through: --unshallow fails when the repository is already complete.
+  }
+
+  try {
+    await withCwd(
+      $`git fetch origin --deepen=1000000 +refs/heads/${branchName}:${branchName}`,
+      cwd,
+    ).quiet();
+    return;
+  } catch {
+    // Last fallback for complete repositories that reject --deepen.
+  }
+
+  await withCwd(
+    $`git fetch origin +refs/heads/${branchName}:${branchName}`,
+    cwd,
+  ).quiet();
+}
+
 export async function setupBranch(
   octokits: Octokits,
   githubData: FetchDataResult,
   context: ParsedGitHubContext,
+  options: SetupBranchOptions = {},
 ): Promise<BranchInfo> {
+  const { cwd, setOutput = core.setOutput } = options;
   const { owner, repo } = context.repository;
   const entityNumber = context.entityNumber;
   const { baseBranch, branchPrefix } = context.inputs;
@@ -82,13 +197,21 @@ export async function setupBranch(
         throw new Error("PR data is missing isCrossRepository");
       }
 
-      const { fetchRef, checkoutBranch, lettaBranch } =
+      const { fetchRef, checkoutBranch, lettaBranch, legacyLettaBranch } =
         getPullRequestBranchPlan(
           entityNumber,
           prData.headRefName,
           prData.isCrossRepository,
           branchPrefix,
         );
+
+      if (lettaBranch) {
+        await assertValidBranchName(lettaBranch, cwd);
+      }
+      const validLegacyLettaBranch =
+        legacyLettaBranch && (await isValidBranchName(legacyLettaBranch, cwd))
+          ? legacyLettaBranch
+          : undefined;
 
       // Determine optimal fetch depth based on PR commit count, with a minimum of 20
       const commitCount = prData.commits.totalCount;
@@ -100,11 +223,12 @@ export async function setupBranch(
 
       // GitHub exposes pull/<number>/head for both same-repo and fork PRs.
       // Fork PRs use a synthetic local branch to avoid clobbering branches like main.
-      await $`git fetch origin --depth=${fetchDepth} ${fetchRef}`;
-      await $`git checkout -B ${checkoutBranch} FETCH_HEAD`;
+      await withCwd($`git fetch origin --depth=${fetchDepth} ${fetchRef}`, cwd);
+      await withCwd($`git checkout -B ${checkoutBranch} FETCH_HEAD`, cwd);
       githubData.changedFilesWithSHA = computeChangedFileSHAs(
         true,
         githubData.changedFiles,
+        cwd,
       );
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
@@ -123,20 +247,58 @@ export async function setupBranch(
         throw new Error("Fork PR checkout requires a Letta branch");
       }
 
-      if (await remoteBranchExists(lettaBranch)) {
-        console.log(`Reusing existing Letta branch: ${lettaBranch}`);
-        await $`git fetch origin --depth=${fetchDepth} +refs/heads/${lettaBranch}:${lettaBranch}`;
-        await $`git checkout ${lettaBranch} --`;
-      } else {
-        await $`git checkout -b ${lettaBranch}`;
+      let existingLettaBranch: string | undefined;
+      if (await remoteBranchExists(lettaBranch, cwd)) {
+        existingLettaBranch = lettaBranch;
+      } else if (
+        validLegacyLettaBranch &&
+        (await remoteBranchExists(validLegacyLettaBranch, cwd))
+      ) {
+        existingLettaBranch = validLegacyLettaBranch;
       }
 
-      core.setOutput("LETTA_BRANCH", lettaBranch);
-      core.setOutput("BASE_BRANCH", baseBranch);
+      const activeLettaBranch = existingLettaBranch ?? lettaBranch;
+
+      if (existingLettaBranch) {
+        const branchKind =
+          activeLettaBranch === validLegacyLettaBranch ? "legacy " : "";
+        console.log(
+          `Reusing existing ${branchKind}Letta branch: ${activeLettaBranch}`,
+        );
+        await withCwd(
+          $`git fetch origin --depth=${fetchDepth} +refs/heads/${activeLettaBranch}:${activeLettaBranch}`,
+          cwd,
+        );
+        if (
+          !(await branchContainsCommit(activeLettaBranch, checkoutBranch, cwd))
+        ) {
+          console.log(
+            `Deepening existing Letta branch ${activeLettaBranch} before stale branch check...`,
+          );
+          await deepenRemoteBranchHistory(activeLettaBranch, cwd);
+          if (
+            !(await branchContainsCommit(
+              activeLettaBranch,
+              checkoutBranch,
+              cwd,
+            ))
+          ) {
+            throw new Error(
+              `Existing Letta branch "${activeLettaBranch}" does not contain the latest PR head. Rebase or delete that branch before rerunning.`,
+            );
+          }
+        }
+        await withCwd($`git checkout ${activeLettaBranch}`, cwd);
+      } else {
+        await withCwd($`git checkout -b ${lettaBranch}`, cwd);
+      }
+
+      setOutput("LETTA_BRANCH", activeLettaBranch);
+      setOutput("BASE_BRANCH", baseBranch);
       return {
         baseBranch,
-        lettaBranch,
-        currentBranch: lettaBranch,
+        lettaBranch: activeLettaBranch,
+        currentBranch: activeLettaBranch,
       };
     }
   }
@@ -190,12 +352,12 @@ export async function setupBranch(
 
       // Ensure we're on the source branch
       console.log(`Fetching and checking out source branch: ${sourceBranch}`);
-      await $`git fetch origin ${sourceBranch} --depth=1`;
-      await $`git checkout ${sourceBranch}`;
+      await withCwd($`git fetch origin ${sourceBranch} --depth=1`, cwd);
+      await withCwd($`git checkout ${sourceBranch}`, cwd);
 
       // Set outputs for GitHub Actions
-      core.setOutput("LETTA_BRANCH", newBranch);
-      core.setOutput("BASE_BRANCH", sourceBranch);
+      setOutput("LETTA_BRANCH", newBranch);
+      setOutput("BASE_BRANCH", sourceBranch);
       return {
         baseBranch: sourceBranch,
         lettaBranch: newBranch,
@@ -210,19 +372,19 @@ export async function setupBranch(
 
     // Fetch and checkout the source branch first to ensure we branch from the correct base
     console.log(`Fetching and checking out source branch: ${sourceBranch}`);
-    await $`git fetch origin ${sourceBranch} --depth=1`;
-    await $`git checkout ${sourceBranch}`;
+    await withCwd($`git fetch origin ${sourceBranch} --depth=1`, cwd);
+    await withCwd($`git checkout ${sourceBranch}`, cwd);
 
     // Create and checkout the new branch from the source branch
-    await $`git checkout -b ${newBranch}`;
+    await withCwd($`git checkout -b ${newBranch}`, cwd);
 
     console.log(
       `Successfully created and checked out local branch: ${newBranch}`,
     );
 
     // Set outputs for GitHub Actions
-    core.setOutput("LETTA_BRANCH", newBranch);
-    core.setOutput("BASE_BRANCH", sourceBranch);
+    setOutput("LETTA_BRANCH", newBranch);
+    setOutput("BASE_BRANCH", sourceBranch);
     return {
       baseBranch: sourceBranch,
       lettaBranch: newBranch,

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -11,13 +11,48 @@ import * as core from "@actions/core";
 import type { ParsedGitHubContext } from "../context";
 import type { GitHubPullRequest } from "../types";
 import type { Octokits } from "../api/client";
-import type { FetchDataResult } from "../data/fetcher";
+import { computeChangedFileSHAs, type FetchDataResult } from "../data/fetcher";
 
 export type BranchInfo = {
   baseBranch: string;
   lettaBranch?: string;
   currentBranch: string;
 };
+
+export type PullRequestBranchPlan = {
+  fetchRef: string;
+  checkoutBranch: string;
+  lettaBranch?: string;
+};
+
+export function getPullRequestBranchPlan(
+  entityNumber: number,
+  headRefName: string,
+  isCrossRepository: boolean,
+  branchPrefix: string,
+): PullRequestBranchPlan {
+  const checkoutBranch = isCrossRepository
+    ? `letta-pr-${entityNumber}`
+    : headRefName;
+  return {
+    fetchRef: `refs/pull/${entityNumber}/head`,
+    checkoutBranch,
+    ...(isCrossRepository && {
+      lettaBranch: `${branchPrefix}pr-${entityNumber}-review`
+        .toLowerCase()
+        .substring(0, 50),
+    }),
+  };
+}
+
+async function remoteBranchExists(branchName: string): Promise<boolean> {
+  try {
+    await $`git ls-remote --exit-code --heads origin ${branchName}`.quiet();
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export async function setupBranch(
   octokits: Octokits,
@@ -43,7 +78,17 @@ export async function setupBranch(
       // Handle open PR: Checkout the PR branch
       console.log("This is an open PR, checking out PR branch...");
 
-      const branchName = prData.headRefName;
+      if (typeof prData.isCrossRepository !== "boolean") {
+        throw new Error("PR data is missing isCrossRepository");
+      }
+
+      const { fetchRef, checkoutBranch, lettaBranch } =
+        getPullRequestBranchPlan(
+          entityNumber,
+          prData.headRefName,
+          prData.isCrossRepository,
+          branchPrefix,
+        );
 
       // Determine optimal fetch depth based on PR commit count, with a minimum of 20
       const commitCount = prData.commits.totalCount;
@@ -53,18 +98,45 @@ export async function setupBranch(
         `PR #${entityNumber}: ${commitCount} commits, using fetch depth ${fetchDepth}`,
       );
 
-      // Execute git commands to checkout PR branch (dynamic depth based on PR size)
-      await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
-      await $`git checkout ${branchName} --`;
+      // GitHub exposes pull/<number>/head for both same-repo and fork PRs.
+      // Fork PRs use a synthetic local branch to avoid clobbering branches like main.
+      await $`git fetch origin --depth=${fetchDepth} ${fetchRef}`;
+      await $`git checkout -B ${checkoutBranch} FETCH_HEAD`;
+      githubData.changedFilesWithSHA = computeChangedFileSHAs(
+        true,
+        githubData.changedFiles,
+      );
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
 
       // For open PRs, we need to get the base branch of the PR
       const baseBranch = prData.baseRefName;
 
+      if (!prData.isCrossRepository) {
+        return {
+          baseBranch,
+          currentBranch: checkoutBranch,
+        };
+      }
+
+      if (!lettaBranch) {
+        throw new Error("Fork PR checkout requires a Letta branch");
+      }
+
+      if (await remoteBranchExists(lettaBranch)) {
+        console.log(`Reusing existing Letta branch: ${lettaBranch}`);
+        await $`git fetch origin --depth=${fetchDepth} +refs/heads/${lettaBranch}:${lettaBranch}`;
+        await $`git checkout ${lettaBranch} --`;
+      } else {
+        await $`git checkout -b ${lettaBranch}`;
+      }
+
+      core.setOutput("LETTA_BRANCH", lettaBranch);
+      core.setOutput("BASE_BRANCH", baseBranch);
       return {
         baseBranch,
-        currentBranch: branchName,
+        lettaBranch,
+        currentBranch: lettaBranch,
       };
     }
   }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -57,6 +57,7 @@ export type GitHubPullRequest = {
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
+  isCrossRepository: boolean;
   createdAt: string;
   updatedAt?: string;
   lastEditedAt?: string;

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -7,6 +7,7 @@ import { setupBranch } from "../../github/operations/branch";
 import { configureGitAuth } from "../../github/operations/git-config";
 import {
   fetchGitHubData,
+  computeChangedFileSHAs,
   extractTriggerTimestamp,
 } from "../../github/data/fetcher";
 import { createPrompt, generateDefaultPrompt } from "../../create-prompt";
@@ -224,6 +225,12 @@ export const tagMode: Mode = {
 
     // Setup branch
     const branchInfo = await setupBranch(octokit, githubData, context);
+    if (githubData.changedFilesWithSHA.length === 0) {
+      githubData.changedFilesWithSHA = computeChangedFileSHAs(
+        context.isPR,
+        githubData.changedFiles,
+      );
+    }
 
     // Configure git authentication if not using commit signing
     if (!context.inputs.useCommitSigning) {

--- a/test/branch.test.ts
+++ b/test/branch.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { execFileSync } from "child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import * as core from "@actions/core";
 import {
   getPullRequestBranchPlan,
   setupBranch,
@@ -25,7 +24,23 @@ function gitWithInput(cwd: string, args: string[], input: string): string {
   }).trim();
 }
 
-function createRemoteWithPullRef(options?: { reviewBranch?: boolean }) {
+function createOutputCollector() {
+  const calls: Array<[string, string]> = [];
+  return {
+    calls,
+    setOutput: (name: string, value: string) => {
+      calls.push([name, value]);
+    },
+  };
+}
+
+function createRemoteWithPullRef(options?: {
+  reviewBranch?: boolean;
+  reviewBranchName?: string;
+  reviewBranchExtraCommits?: number;
+  advancePullRefAfterReviewBranch?: boolean;
+  nestedReviewBranchOnly?: boolean;
+}) {
   const root = mkdtempSync(join(tmpdir(), "letta-branch-test-"));
   const remote = join(root, "remote.git");
   const seed = join(root, "seed");
@@ -47,14 +62,33 @@ function createRemoteWithPullRef(options?: { reviewBranch?: boolean }) {
   writeFileSync(join(seed, "feature.txt"), "feature\n");
   git(seed, ["add", "feature.txt"]);
   git(seed, ["commit", "-m", "feature"]);
+  const featureHead = git(seed, ["rev-parse", "HEAD"]);
   git(seed, ["push", "origin", "HEAD:refs/pull/37/head"]);
 
-  if (options?.reviewBranch) {
+  if (options?.reviewBranch || options?.reviewBranchName) {
+    const reviewBranchName = options.reviewBranchName ?? "letta/pr-37-review";
     writeFileSync(join(seed, "feature.txt"), "review branch\n");
     writeFileSync(join(seed, "review.txt"), "existing review\n");
     git(seed, ["add", "feature.txt", "review.txt"]);
     git(seed, ["commit", "-m", "existing review branch"]);
-    git(seed, ["push", "origin", "HEAD:refs/heads/letta/pr-37-review"]);
+    for (let i = 1; i <= (options.reviewBranchExtraCommits ?? 0); i++) {
+      writeFileSync(join(seed, `review-${i}.txt`), `review ${i}\n`);
+      git(seed, ["add", `review-${i}.txt`]);
+      git(seed, ["commit", "-m", `review update ${i}`]);
+    }
+    git(seed, ["push", "origin", `HEAD:refs/heads/${reviewBranchName}`]);
+  }
+
+  if (options?.advancePullRefAfterReviewBranch) {
+    git(seed, ["reset", "--hard", featureHead]);
+    writeFileSync(join(seed, "updated.txt"), "updated PR head\n");
+    git(seed, ["add", "updated.txt"]);
+    git(seed, ["commit", "-m", "advance pull ref"]);
+    git(seed, ["push", "origin", "HEAD:refs/pull/37/head"]);
+  }
+
+  if (options?.nestedReviewBranchOnly) {
+    git(seed, ["push", "origin", "HEAD:refs/heads/foo/letta/pr-37-review"]);
   }
 
   execFileSync("git", ["clone", "--branch", "main", remote, worktree], {
@@ -101,6 +135,16 @@ function createBranchContext() {
   } as any;
 }
 
+function createBranchContextWithPrefix(branchPrefix: string) {
+  return {
+    ...createBranchContext(),
+    inputs: {
+      baseBranch: "",
+      branchPrefix,
+    },
+  } as any;
+}
+
 describe("setupBranch", () => {
   test("uses a synthetic checkout and review branch for fork PRs", () => {
     expect(getPullRequestBranchPlan(37, "main", true, "letta/")).toEqual({
@@ -126,22 +170,23 @@ describe("setupBranch", () => {
         "feature",
         true,
         "LETTA-REVIEW-BRANCH-WITH-A-LONG-PREFIX-",
-      ).lettaBranch,
-    ).toBe("letta-review-branch-with-a-long-prefix-pr-123-revi");
+      ),
+    ).toMatchObject({
+      lettaBranch: "letta-review-branch-with-a-long-pr-123-review",
+      legacyLettaBranch: "letta-review-branch-with-a-long-prefix-pr-123-revi",
+    });
   });
 
   test("resets a same-repo PR branch even when it is already checked out", async () => {
     const { root, worktree } = createRemoteWithPullRef();
-    const previousCwd = process.cwd();
 
     try {
       git(worktree, ["checkout", "-b", "feature"]);
-      process.chdir(worktree);
-
       const result = await setupBranch(
         {} as any,
         createPullRequestData(false),
         createBranchContext(),
+        { cwd: worktree },
       );
 
       expect(result).toEqual({
@@ -155,7 +200,6 @@ describe("setupBranch", () => {
         "feature",
       );
     } finally {
-      process.chdir(previousCwd);
       rmSync(root, { recursive: true, force: true });
     }
   });
@@ -164,17 +208,15 @@ describe("setupBranch", () => {
     const { root, worktree } = createRemoteWithPullRef({
       reviewBranch: true,
     });
-    const previousCwd = process.cwd();
-    const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
 
     try {
-      process.chdir(worktree);
-
       const githubData = createPullRequestData(true);
+      const outputs = createOutputCollector();
       const result = await setupBranch(
         {} as any,
         githubData,
         createBranchContext(),
+        { cwd: worktree, setOutput: outputs.setOutput },
       );
 
       expect(result).toEqual({
@@ -194,14 +236,157 @@ describe("setupBranch", () => {
       expect(githubData.changedFilesWithSHA[0]?.sha).toBe(
         gitWithInput(worktree, ["hash-object", "--stdin"], "feature\n"),
       );
-      expect(setOutputSpy).toHaveBeenCalledWith(
+      expect(outputs.calls).toContainEqual([
         "LETTA_BRANCH",
         "letta/pr-37-review",
-      );
-      expect(setOutputSpy).toHaveBeenCalledWith("BASE_BRANCH", "main");
+      ]);
+      expect(outputs.calls).toContainEqual(["BASE_BRANCH", "main"]);
     } finally {
-      setOutputSpy.mockRestore();
-      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("reuses legacy truncated Letta branch names for fork PR follow-ups", async () => {
+    const branchPrefix = "LETTA-REVIEW-BRANCH-WITH-A-LONG-PREFIX-";
+    const legacyLettaBranch = getPullRequestBranchPlan(
+      37,
+      "feature",
+      true,
+      branchPrefix,
+    ).legacyLettaBranch;
+    expect(legacyLettaBranch).toBe(
+      "letta-review-branch-with-a-long-prefix-pr-37-revie",
+    );
+    if (!legacyLettaBranch) {
+      throw new Error("Expected a legacy branch fallback");
+    }
+    const { root, worktree } = createRemoteWithPullRef({
+      reviewBranchName: legacyLettaBranch,
+    });
+
+    try {
+      const outputs = createOutputCollector();
+      const result = await setupBranch(
+        {} as any,
+        createPullRequestData(true),
+        createBranchContextWithPrefix(branchPrefix),
+        { cwd: worktree, setOutput: outputs.setOutput },
+      );
+
+      expect(result).toEqual({
+        baseBranch: "main",
+        lettaBranch: legacyLettaBranch,
+        currentBranch: legacyLettaBranch,
+      });
+      expect(git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(
+        legacyLettaBranch,
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:review.txt"])).toBe(
+        "existing review",
+      );
+      expect(outputs.calls).toContainEqual(["LETTA_BRANCH", legacyLettaBranch]);
+      expect(outputs.calls).toContainEqual(["BASE_BRANCH", "main"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("deepens long-lived Letta branches before stale branch rejection", async () => {
+    const { root, worktree } = createRemoteWithPullRef({
+      reviewBranch: true,
+      reviewBranchExtraCommits: 25,
+    });
+
+    try {
+      const result = await setupBranch(
+        {} as any,
+        createPullRequestData(true),
+        createBranchContext(),
+        { cwd: worktree, setOutput: createOutputCollector().setOutput },
+      );
+
+      expect(result).toEqual({
+        baseBranch: "main",
+        lettaBranch: "letta/pr-37-review",
+        currentBranch: "letta/pr-37-review",
+      });
+      expect(git(worktree, ["cat-file", "-p", "HEAD:feature.txt"])).toBe(
+        "review branch",
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:review-25.txt"])).toBe(
+        "review 25",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects stale remote Letta branches that miss the latest fork PR head", async () => {
+    const { root, worktree } = createRemoteWithPullRef({
+      reviewBranch: true,
+      advancePullRefAfterReviewBranch: true,
+    });
+
+    try {
+      await expect(
+        setupBranch(
+          {} as any,
+          createPullRequestData(true),
+          createBranchContext(),
+          { cwd: worktree, setOutput: createOutputCollector().setOutput },
+        ),
+      ).rejects.toThrow("does not contain the latest PR head");
+      expect(git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(
+        "letta-pr-37",
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:updated.txt"])).toBe(
+        "updated PR head",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not treat nested remote branch suffix matches as exact review branches", async () => {
+    const { root, worktree } = createRemoteWithPullRef({
+      nestedReviewBranchOnly: true,
+    });
+
+    try {
+      const result = await setupBranch(
+        {} as any,
+        createPullRequestData(true),
+        createBranchContext(),
+        { cwd: worktree, setOutput: createOutputCollector().setOutput },
+      );
+
+      expect(result).toEqual({
+        baseBranch: "main",
+        lettaBranch: "letta/pr-37-review",
+        currentBranch: "letta/pr-37-review",
+      });
+      expect(git(worktree, ["cat-file", "-p", "HEAD:feature.txt"])).toBe(
+        "feature",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid generated review branch names before reuse fetches", async () => {
+    const { root, worktree } = createRemoteWithPullRef();
+
+    try {
+      await expect(
+        setupBranch(
+          {} as any,
+          createPullRequestData(true),
+          createBranchContextWithPrefix("bad*prefix/"),
+          { cwd: worktree },
+        ),
+      ).rejects.toThrow("Invalid generated branch name");
+      expect(git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("main");
+    } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/test/branch.test.ts
+++ b/test/branch.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as core from "@actions/core";
+import {
+  getPullRequestBranchPlan,
+  setupBranch,
+} from "../src/github/operations/branch";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function gitWithInput(cwd: string, args: string[], input: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    input,
+  }).trim();
+}
+
+function createRemoteWithPullRef(options?: { reviewBranch?: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), "letta-branch-test-"));
+  const remote = join(root, "remote.git");
+  const seed = join(root, "seed");
+  const worktree = join(root, "worktree");
+
+  execFileSync("git", ["init", "--bare", remote], { stdio: "ignore" });
+  execFileSync("git", ["init", seed], { stdio: "ignore" });
+  git(seed, ["config", "user.email", "test@example.com"]);
+  git(seed, ["config", "user.name", "Test User"]);
+
+  writeFileSync(join(seed, "README.md"), "base\n");
+  git(seed, ["add", "README.md"]);
+  git(seed, ["commit", "-m", "initial"]);
+  git(seed, ["branch", "-M", "main"]);
+  git(seed, ["remote", "add", "origin", remote]);
+  git(seed, ["push", "origin", "main"]);
+
+  git(seed, ["checkout", "-b", "feature"]);
+  writeFileSync(join(seed, "feature.txt"), "feature\n");
+  git(seed, ["add", "feature.txt"]);
+  git(seed, ["commit", "-m", "feature"]);
+  git(seed, ["push", "origin", "HEAD:refs/pull/37/head"]);
+
+  if (options?.reviewBranch) {
+    writeFileSync(join(seed, "feature.txt"), "review branch\n");
+    writeFileSync(join(seed, "review.txt"), "existing review\n");
+    git(seed, ["add", "feature.txt", "review.txt"]);
+    git(seed, ["commit", "-m", "existing review branch"]);
+    git(seed, ["push", "origin", "HEAD:refs/heads/letta/pr-37-review"]);
+  }
+
+  execFileSync("git", ["clone", "--branch", "main", remote, worktree], {
+    stdio: "ignore",
+  });
+
+  return { root, worktree };
+}
+
+function createPullRequestData(isCrossRepository: boolean) {
+  return {
+    contextData: {
+      state: "OPEN",
+      baseRefName: "main",
+      headRefName: "feature",
+      isCrossRepository,
+      commits: { totalCount: 1 },
+    },
+    changedFiles: [
+      {
+        path: "feature.txt",
+        additions: 1,
+        deletions: 0,
+        changeType: "ADDED",
+      },
+    ],
+    changedFilesWithSHA: [],
+  } as any;
+}
+
+function createBranchContext() {
+  return {
+    repository: {
+      owner: "owner",
+      repo: "repo",
+      full_name: "owner/repo",
+    },
+    entityNumber: 37,
+    isPR: true,
+    inputs: {
+      baseBranch: "",
+      branchPrefix: "letta/",
+    },
+  } as any;
+}
+
+describe("setupBranch", () => {
+  test("uses a synthetic checkout and review branch for fork PRs", () => {
+    expect(getPullRequestBranchPlan(37, "main", true, "letta/")).toEqual({
+      fetchRef: "refs/pull/37/head",
+      checkoutBranch: "letta-pr-37",
+      lettaBranch: "letta/pr-37-review",
+    });
+  });
+
+  test("keeps same-repo PR branch names for direct push behavior", () => {
+    expect(
+      getPullRequestBranchPlan(37, "add-morph-warpgrep", false, "letta/"),
+    ).toEqual({
+      fetchRef: "refs/pull/37/head",
+      checkoutBranch: "add-morph-warpgrep",
+    });
+  });
+
+  test("normalizes and truncates fork review branches", () => {
+    expect(
+      getPullRequestBranchPlan(
+        123,
+        "feature",
+        true,
+        "LETTA-REVIEW-BRANCH-WITH-A-LONG-PREFIX-",
+      ).lettaBranch,
+    ).toBe("letta-review-branch-with-a-long-prefix-pr-123-revi");
+  });
+
+  test("resets a same-repo PR branch even when it is already checked out", async () => {
+    const { root, worktree } = createRemoteWithPullRef();
+    const previousCwd = process.cwd();
+
+    try {
+      git(worktree, ["checkout", "-b", "feature"]);
+      process.chdir(worktree);
+
+      const result = await setupBranch(
+        {} as any,
+        createPullRequestData(false),
+        createBranchContext(),
+      );
+
+      expect(result).toEqual({
+        baseBranch: "main",
+        currentBranch: "feature",
+      });
+      expect(git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(
+        "feature",
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:feature.txt"])).toBe(
+        "feature",
+      );
+    } finally {
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("reuses an existing remote Letta branch for fork PR follow-ups", async () => {
+    const { root, worktree } = createRemoteWithPullRef({
+      reviewBranch: true,
+    });
+    const previousCwd = process.cwd();
+    const setOutputSpy = spyOn(core, "setOutput").mockImplementation(() => {});
+
+    try {
+      process.chdir(worktree);
+
+      const githubData = createPullRequestData(true);
+      const result = await setupBranch(
+        {} as any,
+        githubData,
+        createBranchContext(),
+      );
+
+      expect(result).toEqual({
+        baseBranch: "main",
+        lettaBranch: "letta/pr-37-review",
+        currentBranch: "letta/pr-37-review",
+      });
+      expect(git(worktree, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(
+        "letta/pr-37-review",
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:review.txt"])).toBe(
+        "existing review",
+      );
+      expect(git(worktree, ["cat-file", "-p", "HEAD:feature.txt"])).toBe(
+        "review branch",
+      );
+      expect(githubData.changedFilesWithSHA[0]?.sha).toBe(
+        gitWithInput(worktree, ["hash-object", "--stdin"], "feature\n"),
+      );
+      expect(setOutputSpy).toHaveBeenCalledWith(
+        "LETTA_BRANCH",
+        "letta/pr-37-review",
+      );
+      expect(setOutputSpy).toHaveBeenCalledWith("BASE_BRANCH", "main");
+    } finally {
+      setOutputSpy.mockRestore();
+      process.chdir(previousCwd);
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, jest } from "bun:test";
+import { rmSync, writeFileSync } from "fs";
 import {
+  computeChangedFileSHAs,
   extractTriggerTimestamp,
   fetchGitHubData,
   filterCommentsToTriggerTime,
@@ -15,6 +17,64 @@ import {
   mockIssueOpenedContext,
 } from "./mockContext";
 import type { GitHubComment, GitHubReview } from "../src/github/types";
+
+describe("computeChangedFileSHAs", () => {
+  it("returns no SHA data outside PR contexts", () => {
+    const result = computeChangedFileSHAs(false, [
+      {
+        path: "src/example.ts",
+        additions: 1,
+        deletions: 0,
+        changeType: "ADDED",
+      },
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("marks deleted files without touching the worktree", () => {
+    const result = computeChangedFileSHAs(true, [
+      {
+        path: "src/deleted.ts",
+        additions: 0,
+        deletions: 4,
+        changeType: "DELETED",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        path: "src/deleted.ts",
+        additions: 0,
+        deletions: 4,
+        changeType: "DELETED",
+        sha: "deleted",
+      },
+    ]);
+  });
+
+  it("uses -- before hashing file paths", () => {
+    const path = "--leading-dash.ts";
+
+    try {
+      writeFileSync(path, "test content\n");
+
+      const result = computeChangedFileSHAs(true, [
+        {
+          path,
+          additions: 1,
+          deletions: 0,
+          changeType: "ADDED",
+        },
+      ]);
+
+      expect(result[0]?.sha).not.toBe("unknown");
+      expect(result[0]?.sha).toHaveLength(40);
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+});
 
 describe("extractTriggerTimestamp", () => {
   it("should extract timestamp from IssueCommentEvent", () => {
@@ -641,6 +701,54 @@ describe("fetchGitHubData integration with time filtering", () => {
     );
     // Only review 1 should have its body processed (before trigger and not edited after)
     expect(reviewsInMap.length).toBeLessThanOrEqual(1);
+  });
+
+  it("should defer changed-file SHA computation until after PR checkout", async () => {
+    const mockOctokits = {
+      graphql: jest.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            number: 654,
+            title: "Test PR",
+            body: "PR body",
+            author: { login: "author" },
+            comments: { nodes: [] },
+            files: {
+              nodes: [
+                {
+                  path: "new-file.ts",
+                  additions: 10,
+                  deletions: 0,
+                  changeType: "ADDED",
+                },
+              ],
+            },
+            reviews: { nodes: [] },
+          },
+        },
+        user: { login: "trigger-user" },
+      }),
+      rest: jest.fn() as any,
+    };
+
+    const result = await fetchGitHubData({
+      octokits: mockOctokits as any,
+      repository: "test-owner/test-repo",
+      prNumber: "654",
+      isPR: true,
+      triggerUsername: "trigger-user",
+      triggerTime: "2024-01-15T12:00:00Z",
+    });
+
+    expect(result.changedFiles).toEqual([
+      {
+        path: "new-file.ts",
+        additions: 10,
+        deletions: 0,
+        changeType: "ADDED",
+      },
+    ]);
+    expect(result.changedFilesWithSHA).toEqual([]);
   });
 
   it("should filter review comments based on trigger time", async () => {

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, jest } from "bun:test";
-import { rmSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   computeChangedFileSHAs,
   extractTriggerTimestamp,
@@ -53,25 +55,30 @@ describe("computeChangedFileSHAs", () => {
     ]);
   });
 
-  it("uses -- before hashing file paths", () => {
+  it("uses -- before hashing file paths", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "hash-object-test-"));
     const path = "--leading-dash.ts";
 
     try {
-      writeFileSync(path, "test content\n");
+      writeFileSync(join(tempDir, path), "test content\n");
 
-      const result = computeChangedFileSHAs(true, [
-        {
-          path,
-          additions: 1,
-          deletions: 0,
-          changeType: "ADDED",
-        },
-      ]);
+      const result = computeChangedFileSHAs(
+        true,
+        [
+          {
+            path,
+            additions: 1,
+            deletions: 0,
+            changeType: "ADDED",
+          },
+        ],
+        tempDir,
+      );
 
       expect(result[0]?.sha).not.toBe("unknown");
       expect(result[0]?.sha).toHaveLength(40);
     } finally {
-      rmSync(path, { force: true });
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -24,6 +24,7 @@ describe("formatContext", () => {
       baseRefName: "main",
       headRefName: "feature/test",
       headRefOid: "abc123",
+      isCrossRepository: false,
       createdAt: "2023-01-01T00:00:00Z",
       additions: 50,
       deletions: 30,


### PR DESCRIPTION
Fixes #19

## Summary
- fetch open PRs through `refs/pull/<number>/head` so fork PR heads are available from the base repo
- compute changed-file SHAs after checking out the PR head, including fork follow-ups that reuse an existing Letta branch
- keep same-repo PRs on their original branch while using a maintainer-side Letta branch for fork PR changes

## Tests
- `bun test`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`