### PR TITLE
fix: allow maintainer-approved external PR runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ steps:
 
 ## Security
 
-By default, only repository collaborators with write access can trigger the action. This prevents unauthorized users from consuming your API credits.
+By default, only repository collaborators with write access can trigger the action. This prevents unauthorized users from consuming your API credits. For fork pull requests, approving the workflow in GitHub also works: the action verifies that the user who started the approved run attempt has write access before proceeding.
 
 Use `allowed_bots` for bot users or `allowed_non_write_users` to allow specific usernames without write permissions (use with caution).
 

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -81,6 +81,8 @@ type BaseContext = {
     full_name: string;
   };
   actor: string;
+  /** User who started the current run attempt (for example, a maintainer rerunning an approved fork workflow). */
+  triggeringActor?: string;
   inputs: {
     prompt: string;
     triggerPhrase: string;
@@ -138,6 +140,7 @@ export function parseGitHubContext(): GitHubContext {
       full_name: `${context.repo.owner}/${context.repo.repo}`,
     },
     actor: context.actor,
+    triggeringActor: process.env.GITHUB_TRIGGERING_ACTOR || context.actor,
     inputs: {
       prompt: process.env.PROMPT || "",
       triggerPhrase: process.env.TRIGGER_PHRASE ?? "@letta-code",

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -49,7 +49,7 @@ export async function checkWritePermissions(
       return true;
     }
 
-    // Check permissions directly using the permission endpoint
+    // Check permissions directly using the permission endpoint.
     const response = await octokit.repos.getCollaboratorPermissionLevel({
       owner: repository.owner,
       repo: repository.repo,
@@ -62,10 +62,42 @@ export async function checkWritePermissions(
     if (permissionLevel === "admin" || permissionLevel === "write") {
       core.info(`Actor has write access: ${permissionLevel}`);
       return true;
-    } else {
-      core.warning(`Actor has insufficient permissions: ${permissionLevel}`);
+    }
+
+    // GitHub keeps github.actor set to the external contributor when a
+    // maintainer approves and starts (or reruns) a fork workflow. The
+    // maintainer is exposed separately as github.triggering_actor. Accept the
+    // run only after independently verifying that user has write access.
+    const triggeringActor = context.triggeringActor;
+    if (triggeringActor && triggeringActor !== actor) {
+      core.info(
+        `Actor has insufficient permissions: ${permissionLevel}; checking triggering actor: ${triggeringActor}`,
+      );
+      const triggeringResponse =
+        await octokit.repos.getCollaboratorPermissionLevel({
+          owner: repository.owner,
+          repo: repository.repo,
+          username: triggeringActor,
+        });
+      const triggeringPermission = triggeringResponse.data.permission;
+      core.info(
+        `Triggering actor permission level retrieved: ${triggeringPermission}`,
+      );
+      if (
+        triggeringPermission === "admin" ||
+        triggeringPermission === "write"
+      ) {
+        core.info(`Triggering actor has write access: ${triggeringPermission}`);
+        return true;
+      }
+      core.warning(
+        `Actor and triggering actor have insufficient permissions: ${permissionLevel}, ${triggeringPermission}`,
+      );
       return false;
     }
+
+    core.warning(`Actor has insufficient permissions: ${permissionLevel}`);
+    return false;
   } catch (error) {
     core.error(`Failed to check permissions: ${error}`);
     throw new Error(`Failed to check permissions for ${actor}: ${error}`);

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -127,6 +127,43 @@ describe("checkWritePermissions", () => {
     );
   });
 
+  test("should allow an external actor when a writer starts the run attempt", async () => {
+    const checkedUsers: string[] = [];
+    const mockOctokit = {
+      repos: {
+        getCollaboratorPermissionLevel: async ({ username }: any) => {
+          checkedUsers.push(username);
+          return {
+            data: { permission: username === "maintainer" ? "write" : "read" },
+          };
+        },
+      },
+    } as any;
+    const context = createContext();
+    context.triggeringActor = "maintainer";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(true);
+    expect(checkedUsers).toEqual(["test-user", "maintainer"]);
+    expect(coreInfoSpy).toHaveBeenCalledWith(
+      "Triggering actor has write access: write",
+    );
+  });
+
+  test("should reject an external actor when the rerunning user is also read-only", async () => {
+    const mockOctokit = createMockOctokit("read");
+    const context = createContext();
+    context.triggeringActor = "other-external-user";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(false);
+    expect(coreWarningSpy).toHaveBeenCalledWith(
+      "Actor and triggering actor have insufficient permissions: read, read",
+    );
+  });
+
   test("should return true for bot user", async () => {
     const mockOctokit = createMockOctokit("none");
     const context = createContext();


### PR DESCRIPTION
## Summary
- recognize `GITHUB_TRIGGERING_ACTOR` separately from the original pull request actor
- allow an approved or rerun external PR workflow only after verifying the triggering maintainer has write access
- preserve rejection when both the contributor and triggering user are read-only

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (452 passing)
- [x] `bun run format:check`

👾 Generated with [Letta Code](https://letta.com)