### PR TITLE
feat: add follow-up prompts for resumed conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ To force a new conversation, use: `@letta-code [--new] start fresh`
 
 This creates a new conversation while keeping the same agent (preserving its memory and learned preferences).
 
+### Follow-up Prompts
+
+Automated agent-mode workflows can provide a shorter `followup_prompt` for runs that resume an existing issue or PR conversation. The initial run uses `prompt`; resumed runs use `followup_prompt`. If `followup_prompt` is empty, every run uses `prompt`.
+
 ## Configuration
 
 | Input                      | Description                                                | Default       |
@@ -167,6 +171,7 @@ This creates a new conversation while keeping the same agent (preserving its mem
 | `model`                    | Model to use (`opus`, `sonnet-4.5`, `haiku`, `gpt-4.1`)    | `opus`        |
 | `environment`              | Execution environment (e.g., `cloud`)                      | None          |
 | `prompt`                   | Auto-trigger with this prompt (for automated workflows)    | None          |
+| `followup_prompt`          | Prompt used when resuming an existing conversation         | `prompt`      |
 | `trigger_phrase`           | Phrase that activates the agent                            | `@letta-code` |
 | `label_trigger`            | Label that triggers the action                             | `letta-code`  |
 | `assignee_trigger`         | Username that triggers when assigned                       | None          |

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Instructions for Letta. Can be a direct prompt or custom template."
     required: false
     default: ""
+  followup_prompt:
+    description: "Instructions for resumed agent-mode conversations. Falls back to prompt when empty."
+    required: false
+    default: ""
 
   # Auth configuration
   letta_api_key:
@@ -156,6 +160,7 @@ runs:
       env:
         MODE: ${{ inputs.mode }}
         PROMPT: ${{ inputs.prompt }}
+        FOLLOWUP_PROMPT: ${{ inputs.followup_prompt }}
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
         LABEL_TRIGGER: ${{ inputs.label_trigger }}

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -83,6 +83,7 @@ type BaseContext = {
   actor: string;
   inputs: {
     prompt: string;
+    followupPrompt?: string;
     triggerPhrase: string;
     assigneeTrigger: string;
     labelTrigger: string;
@@ -140,6 +141,7 @@ export function parseGitHubContext(): GitHubContext {
     actor: context.actor,
     inputs: {
       prompt: process.env.PROMPT || "",
+      followupPrompt: process.env.FOLLOWUP_PROMPT || "",
       triggerPhrase: process.env.TRIGGER_PHRASE ?? "@letta-code",
       assigneeTrigger: process.env.ASSIGNEE_TRIGGER ?? "",
       labelTrigger: process.env.LABEL_TRIGGER ?? "",

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -104,16 +104,6 @@ export const agentMode: Mode = {
       recursive: true,
     });
 
-    // Write the prompt file - use the user's prompt directly
-    const promptContent =
-      context.inputs.prompt ||
-      `Repository: ${context.repository.owner}/${context.repository.repo}`;
-
-    await writeFile(
-      `${process.env.RUNNER_TEMP || "/tmp"}/letta-prompts/letta-prompt.txt`,
-      promptContent,
-    );
-
     // Check for branch info from environment variables (useful for auto-fix workflows)
     const lettaBranch = process.env.LETTA_BRANCH || undefined;
     const baseBranch =
@@ -124,6 +114,7 @@ export const agentMode: Mode = {
     const userLettaArgs = process.env.LETTA_ARGS || "";
 
     // Conversation persistence: search for existing conversation via Letta API
+    let isFollowup = false;
     if (context.inputs.agentId && isEntityContext(context)) {
       core.setOutput("agent_id", context.inputs.agentId);
 
@@ -140,6 +131,7 @@ export const agentMode: Mode = {
 
       if (existingConversationId) {
         // Resume existing conversation
+        isFollowup = true;
         core.setOutput("conversation_id", existingConversationId);
         core.setOutput("is_followup", "true");
         core.setOutput("create_new_conversation", "false");
@@ -155,6 +147,17 @@ export const agentMode: Mode = {
       core.setOutput("agent_id", context.inputs.agentId);
       core.setOutput("create_new_conversation", "true");
     }
+
+    const promptContent =
+      isFollowup && context.inputs.followupPrompt?.trim()
+        ? context.inputs.followupPrompt
+        : context.inputs.prompt ||
+          `Repository: ${context.repository.owner}/${context.repository.repo}`;
+
+    await writeFile(
+      `${process.env.RUNNER_TEMP || "/tmp"}/letta-prompts/letta-prompt.txt`,
+      promptContent,
+    );
 
     core.setOutput("letta_args", userLettaArgs.trim());
 

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -14,6 +14,7 @@ import { LETTA_APP_BOT_ID, LETTA_BOT_LOGIN } from "../src/github/constants";
 
 const defaultInputs = {
   prompt: "",
+  followupPrompt: "",
   triggerPhrase: "/letta-code",
   assigneeTrigger: "",
   labelTrigger: "",

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -13,6 +13,9 @@ import { createMockContext, createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
 import * as lettaClient from "../../src/letta/client";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 describe("Agent Mode", () => {
   let mockContext: GitHubContext;
@@ -20,8 +23,13 @@ describe("Agent Mode", () => {
   let setOutputSpy: any;
   let configureGitAuthSpy: any;
   let findConversationBySummarySpy: any;
+  let originalRunnerTemp: string | undefined;
+  let runnerTemp: string;
 
   beforeEach(() => {
+    originalRunnerTemp = process.env.RUNNER_TEMP;
+    runnerTemp = mkdtempSync(join(tmpdir(), "letta-action-agent-mode-"));
+    process.env.RUNNER_TEMP = runnerTemp;
     mockContext = createMockAutomationContext({
       eventName: "workflow_dispatch",
     });
@@ -52,6 +60,12 @@ describe("Agent Mode", () => {
     setOutputSpy?.mockRestore();
     configureGitAuthSpy?.mockRestore();
     findConversationBySummarySpy?.mockRestore();
+    rmSync(runnerTemp, { recursive: true, force: true });
+    if (originalRunnerTemp === undefined) {
+      delete process.env.RUNNER_TEMP;
+    } else {
+      process.env.RUNNER_TEMP = originalRunnerTemp;
+    }
   });
 
   test("agent mode has correct properties", () => {
@@ -263,14 +277,18 @@ describe("Agent Mode", () => {
       githubToken: "test-token",
     });
 
-    // Note: We can't easily test file creation in this unit test,
-    // but we can verify the method completes without errors
     // With our conditional MCP logic, agent mode with no allowed tools
     // should not include any MCP config
     const callArgs = setOutputSpy.mock.calls[0];
     expect(callArgs[0]).toBe("letta_args");
     // Should be empty or just whitespace when no MCP servers are included
     expect(callArgs[1]).not.toContain("--mcp-config");
+    expect(
+      readFileSync(
+        join(runnerTemp, "letta-prompts", "letta-prompt.txt"),
+        "utf8",
+      ),
+    ).toBe("Custom prompt content");
   });
 
   test("prepare method resumes existing conversation on entity context (PR)", async () => {
@@ -278,6 +296,7 @@ describe("Agent Mode", () => {
       eventName: "pull_request",
       inputs: {
         prompt: "Review this PR",
+        followupPrompt: "Review the latest changes only",
         agentId: "agent-configured",
       },
     });
@@ -305,6 +324,12 @@ describe("Agent Mode", () => {
       "create_new_conversation",
       "false",
     );
+    expect(
+      readFileSync(
+        join(runnerTemp, "letta-prompts", "letta-prompt.txt"),
+        "utf8",
+      ),
+    ).toBe("Review the latest changes only");
   });
 
   test("prepare method creates new conversation when no existing conversation found on entity context", async () => {
@@ -312,6 +337,7 @@ describe("Agent Mode", () => {
       eventName: "pull_request",
       inputs: {
         prompt: "Review this PR",
+        followupPrompt: "Review the latest changes only",
         agentId: "agent-configured",
       },
     });
@@ -333,5 +359,39 @@ describe("Agent Mode", () => {
       "create_new_conversation",
       "true",
     );
+    expect(
+      readFileSync(
+        join(runnerTemp, "letta-prompts", "letta-prompt.txt"),
+        "utf8",
+      ),
+    ).toBe("Review this PR");
+  });
+
+  test("prepare method falls back to prompt when followup_prompt is empty", async () => {
+    const contextWithAgent = createMockContext({
+      eventName: "pull_request",
+      inputs: {
+        prompt: "Review this PR",
+        followupPrompt: "",
+        agentId: "agent-configured",
+      },
+    });
+
+    findConversationBySummarySpy.mockImplementation(
+      async () => "conv-existing-123",
+    );
+
+    await agentMode.prepare({
+      context: contextWithAgent,
+      octokit: { rest: {} } as any,
+      githubToken: "test-token",
+    });
+
+    expect(
+      readFileSync(
+        join(runnerTemp, "letta-prompts", "letta-prompt.txt"),
+        "utf8",
+      ),
+    ).toBe("Review this PR");
   });
 });


### PR DESCRIPTION
## Summary
- add an optional `followup_prompt` action input for automated agent-mode workflows
- use the full `prompt` when creating a conversation and `followup_prompt` when resuming one
- fall back to `prompt` when no follow-up prompt is configured
- document and test initial, resumed, and fallback behavior

## Test plan
- [x] `bun test` (453 tests)
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] validate `action.yml`

Linear: [LET-11162](https://linear.app/letta/issue/LET-11162/support-follow-up-prompts-in-letta-code-action)

👾 Generated with [Letta Code](https://letta.com)