### PR TITLE
fix: omit unreported execution cost

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -406,13 +406,14 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
         markdown += `${resultText}\n\n`;
       }
 
-      // Show tokens if available, otherwise show cost for backwards compatibility
-      if (usage?.total_tokens) {
-        markdown += `**Tokens:** ${usage.total_tokens.toLocaleString()} | **Duration:** ${(duration / 1000).toFixed(1)}s\n\n`;
-      } else {
-        const cost =
-          (data as any).total_cost_usd || (data as any).cost_usd || 0;
+      const totalTokens = usage?.total_tokens;
+      const cost = (data as any).total_cost_usd ?? (data as any).cost_usd;
+      if (typeof totalTokens === "number") {
+        markdown += `**Tokens:** ${totalTokens.toLocaleString()} | **Duration:** ${(duration / 1000).toFixed(1)}s\n\n`;
+      } else if (typeof cost === "number") {
         markdown += `**Cost:** $${cost.toFixed(4)} | **Duration:** ${(duration / 1000).toFixed(1)}s\n\n`;
+      } else {
+        markdown += `**Duration:** ${(duration / 1000).toFixed(1)}s\n\n`;
       }
     }
   }

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -358,6 +358,27 @@ describe("formatGroupedContent", () => {
     expect(result).toContain("**Duration:** 5.7s");
   });
 
+  test("omits cost when execution metrics do not report it", () => {
+    const groupedContent: GroupedContent[] = [
+      {
+        type: "final_result",
+        data: {
+          type: "result",
+          duration_ms: 16400,
+          result: "LGTM",
+          usage: null,
+        } as Turn,
+      },
+    ];
+
+    const result = formatGroupedContent(groupedContent);
+
+    expect(result).toContain("LGTM");
+    expect(result).toContain("**Duration:** 16.4s");
+    expect(result).not.toContain("**Cost:**");
+    expect(result).not.toContain("**Tokens:**");
+  });
+
   test("formats final results with token usage instead of cost", () => {
     const groupedContent: GroupedContent[] = [
       {


### PR DESCRIPTION
## Summary
- stop formatting absent execution cost data as `$0.0000`
- continue showing explicit zero values when the runner actually reports them
- fall back to duration-only output when neither token usage nor cost is available

## Test plan
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run format:check`

Related to [LET-11216](https://linear.app/letta/issue/LET-11216/fix-code-review-workflow-authentication-and-gating).

👾 Generated with [Letta Code](https://letta.com)